### PR TITLE
Expandables should be unregistered in controller upon their disposal.

### DIFF
--- a/lib/expandable.dart
+++ b/lib/expandable.dart
@@ -717,6 +717,7 @@ class _ExpandableIconState extends State<ExpandableIcon>
 
   @override
   void dispose() {
+    controller.removeListener(_expandedStateChanged);
     animationController.dispose();
     super.dispose();
   }


### PR DESCRIPTION
Expandables should be unregistered in controller upon their disposal